### PR TITLE
[Bug Fix] RateDiscountableRegularPhone 생성자의 누락된 field 값 할당 로직 추가

### DIFF
--- a/chapter11/src/main/java/org/eternity/billing/step04/RateDiscountableRegularPhone.java
+++ b/chapter11/src/main/java/org/eternity/billing/step04/RateDiscountableRegularPhone.java
@@ -9,6 +9,7 @@ public class RateDiscountableRegularPhone extends RegularPhone {
 
     public RateDiscountableRegularPhone(Money amount, Duration seconds, Money discountAmount) {
         super(amount, seconds);
+        this.discountAmount = discountAmount;
     }
 
     @Override


### PR DESCRIPTION
field 값 할당 로직 누락으로 인해, `afterCalculated` 메서드 수행 시 `NullPointerException` 이 발생하는 버그가 있었습니다.



+) 책 잘 보고 있습니다. 감사합니다🙂